### PR TITLE
Feat: search by enumerated usb serial

### DIFF
--- a/EasyMCP2221/MCP2221.py
+++ b/EasyMCP2221/MCP2221.py
@@ -143,19 +143,28 @@ class Device:
                 if usbserial is not None:
                     found = False
                     for idx, dev in enumerate(hid.enumerate(self.VID, self.PID)):
-                        try:
+                        # try:
+                        #     self.hidhandler.open_path(dev["path"])
+
+                        #     if usbserial == self.read_flash_info()['USB_SERIAL']:
+                        #         found = True
+                        #         self.usbserial = usbserial # for caching
+                        #         self.devnum = idx
+                        #         break
+                        #     else:
+                        #         self.hidhandler.close()
+
+                        # except:
+                        #     pass
+
+                        # Relies on devices enumerating with usbserial
+                        # Can configure this setting with MCP2221 Utility
+                        if dev["serial_number"] == usbserial:
                             self.hidhandler.open_path(dev["path"])
-
-                            if usbserial == self.read_flash_info()['USB_SERIAL']:
-                                found = True
-                                self.usbserial = usbserial # for caching
-                                self.devnum = idx
-                                break
-                            else:
-                                self.hidhandler.close()
-
-                        except:
-                            pass
+                            found = True
+                            self.usbserial = usbserial # for caching
+                            self.devnum = idx
+                            break
 
                     if not found:
                         raise RuntimeError("No device found with serial number %s or already in use." % usbserial)

--- a/EasyMCP2221/MCP2221.py
+++ b/EasyMCP2221/MCP2221.py
@@ -167,7 +167,7 @@ class Device:
                             break
 
                     if not found:
-                        raise RuntimeError("No device found with serial number %s or already in use." % usbserial)
+                        raise RuntimeError("No device found with serial number %s or already in use. Ensure device is configured to enumerate with serial number." % usbserial)
                     else:
                         break
 

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,10 @@ Reinoso Guzman (https://www.electronicayciencia.com).
 
 Initially based on PyMCP2221A library by Yuta Kitagami (https://github.com/nonNoise/PyMCP2221A).
 
+This fork was created to address a niche use-case of simultaneously communicating with two MCP2221 deivces from separate sessions, specifying by USB serial number. 
+Initialisation behaviour has been changed to only search through enumerated SNs rather than connecting to devices to read flash info, which was causing conflicts. 
+This means that there is a reliance on the MCP2221 devices enumerating with their serial number visible, which is disabled by default but can be enabled in the MCP2221 Utility.
+
 
 License
 ----------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "EasyMCP2221"
-version = "0.0+unreleased.local"
+version = "1.8.3+enumeratedserial"
 authors = [
   { name="Reinoso Guzman", email="electronicayciencia@gmail.com" },
 ]


### PR DESCRIPTION
When identifying device by usbserial, look through serial numbers visible in `dict`s returned by `hid.enumerate()` rather than connecting to devices and reading flash info.

Fixes use-case where reading usbserial from flash was causing communication issues with already opened devices. 

Requires "enumerate with serial number" option to be enabled, which is disabled by default, to be able to identify a device by usbserial.